### PR TITLE
fix: update gql schema fetching parameters

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,7 @@ if [ ! -f "$GQLSCHEMA_FILENAME" ] ; then
     TOKEN=`cat "$TOKEN_FILENAME"`
 
     echo "Fetching the GraphQL schema"
-    run_quicktype --graphql-server-header "Authorization: bearer $TOKEN" \
+    run_quicktype --http-header "Authorization: Bearer $TOKEN" \
         --graphql-introspect "https://api.github.com/graphql" \
         --graphql-schema "$GQLSCHEMA_FILENAME"
 fi


### PR DESCRIPTION
Fixes instantiating the sample repository using setup.sh ( Error: Option parsing failed: Unknown option: --graphql-server-header )
Changes the outdated option param to a new one (--http-header).